### PR TITLE
Simplify annotation API

### DIFF
--- a/banyan/banyan/__init__.py
+++ b/banyan/banyan/__init__.py
@@ -1,6 +1,9 @@
-__version__ = "0.1.1"
+import logging
+import os
 
-from .imports import *
+import boto3
+
+__version__ = "0.2.0"
 
 # Check if AWS region is set. If not, default to us-west-2 and give a warning
 if boto3.Session().region_name == None:
@@ -11,4 +14,7 @@ if boto3.Session().region_name == None:
     )
     os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
 
+from .annotation import Future, record_task
+from .config import configure
 from .constants import *
+from .utils_future_computation import PartitionType

--- a/banyan/banyan/annotation.py
+++ b/banyan/banyan/annotation.py
@@ -87,12 +87,14 @@ def record_task(
             new_future = Future()
             new_futures[results[i]] = new_future
             results[i] = new_future
+            result_ids[i] = new_future.id
     partitioning = _to_list(partitioning)
     for partitioning_map in partitioning:
         if isinstance(partitioning_map, dict):
-            for k, v in partitioning_map.items():
+            for k in list(partitioning_map.keys()):
                 if k in new_futures:
-                    partitioning_map[new_futures[k]] = v
+                    partitioning_map[new_futures[k]] = partitioning_map[k]
+                    partitioning_map.pop(k, None)
 
     # Construct a `FutureComputation` for the new task`
     fc = FutureComputation(
@@ -128,4 +130,7 @@ def record_task(
         # Record the new task
         result._record_task(fc)
 
+    # Return result futures
+    if len(results) == 1:
+        return results[0]
     return results

--- a/banyan/banyan/annotation.py
+++ b/banyan/banyan/annotation.py
@@ -1,10 +1,17 @@
-# TODO: Future class, compute, partitioned_computation
-
 from typing import Any, Dict, List, Optional, Union
-from utils_communication import receive_to_client, send_to_client
-from sessions import get_session_id
-from utils import send_request_get_response
-from utils_future_computation import FutureComputation, PartitionType, _new_future_id, FutureId, TaskGraph
+
+from .sessions import get_session_id
+from .utils import send_request_get_response
+from .utils_communication import receive_to_client, send_to_client
+from .utils_future_computation import (
+    FutureComputation,
+    FutureId,
+    PartitionType,
+    TaskGraph,
+    _new_future_id,
+    is_future_id,
+)
+
 
 class Future:
     def __init__(self):
@@ -19,32 +26,31 @@ class Future:
         self._task_graph.append(fc)
 
     def compute(self):
-        self._record_task(
-            FutureComputation(
-                send_to_client,
-                [self.id],
-                [self.id],
-                [{self.id: PartitionType("Consolidated")}]
-                name="bn_send_to_client",
-            )
-        )
-        resp = send_request_get_response(
+        record_task(self, send_to_client, self, {self: "Consolidated"})
+        send_request_get_response(
             "run_computation",
             {
                 "session_id": get_session_id(),
-                "task_graph": self._task_graph.to_dict()
-                "future_ids": [self.id]
-            }
+                "task_graph": self._task_graph.to_dict(),
+                "future_ids": [self.id],
+            },
         )
         return receive_to_client()
 
-def _futures_to_future_ids(futures: Union[Future,List[Future]]) -> Optional[List[FutureId]]:
+
+def _futures_to_future_ids(
+    futures: Union[Future, List[Future]]
+) -> Optional[List[FutureId]]:
     if isinstance(futures, Future):
         return [futures.id]
     elif futures is None:
         return None
     else:
-        return [(future.id if isinstance(future, Future) else future) for future in futures]
+        return [
+            (future.id if isinstance(future, Future) else future)
+            for future in futures
+        ]
+
 
 def _to_list(l) -> Optional[List]:
     if isinstance(l, List):
@@ -54,26 +60,72 @@ def _to_list(l) -> Optional[List]:
     else:
         return [l]
 
+
+PartitioningSpec = Union[
+    str,
+    PartitionType,
+    Dict[Union[Future, FutureId], Union[PartitionType, List[PartitionType]]],
+]
+
+
 def record_task(
-    results: Union[Future,List[Future]],
+    results: Union[Future, List[Future]],
     func: Any,
-    args: Union[Future,List[Future]],
-    partitioning: List[Dict[Future, Union[PartitionType, List[PartitionType]]]],
-    static=None
+    args: Union[Future, List[Future]],
+    partitioning: Union[PartitioningSpec, List[PartitioningSpec]],
+    static=None,
 ):
+    args = _to_list(args)
+    results = _to_list(results)
+    arg_ids = list(filter(is_future_id, _futures_to_future_ids(args)))
+    result_ids = _futures_to_future_ids(results)
+
+    # Generate new futures if results or partitioning keys are string variable names
+    new_futures: Dict[str, Future] = {}
+    for i in range(len(results)):
+        if isinstance(results[i], str):
+            new_future = Future()
+            new_futures[results[i]] = new_future
+            results[i] = new_future
+    partitioning = _to_list(partitioning)
+    for partitioning_map in partitioning:
+        if isinstance(partitioning_map, dict):
+            for k, v in partitioning_map.items():
+                if k in new_futures:
+                    partitioning_map[new_futures[k]] = v
+
+    # Construct a `FutureComputation` for the new task`
     fc = FutureComputation(
         func,
         _futures_to_future_ids(args),
-        _futures_to_future_ids(results),
+        result_ids,
         [
             {
-                (f.id if isinstance(f, Future) else f): _to_list(pts)
-                for f, pts in p.items()
+                (f.id if isinstance(f, Future) else f): (
+                    pt if isinstance(pt, PartitionType) else PartitionType(pt)
+                )
+                for f, pt in p.items()
+            }
+            if isinstance(p, dict)
+            else {
+                f: p if isinstance(p, PartitionType) else PartitionType(p)
+                for f in arg_ids + result_ids
             }
             for p in partitioning
         ],
         static=_futures_to_future_ids(static),
-        name=func.__name__
+        name=func.__name__,
     )
-    for result in _to_list(results):
+
+    # Record the task for each result
+    for result in results:
+        # Record each task required to construct the arguments
+        for arg in args:
+            if isinstance(arg, Future):
+                for task in arg._task_graph:
+                    result._record_task(task)
+
+        # Record the new task
         result._record_task(fc)
+
+    return results

--- a/banyan/banyan/config.py
+++ b/banyan/banyan/config.py
@@ -3,9 +3,11 @@ This file contains utils files related to setting and
 loading configurations.
 """
 
+import os
 from copy import deepcopy
+from typing import Optional
 
-from banyan.imports import *
+import toml
 
 banyan_config = None  # Global variable representing configuration
 

--- a/banyan/banyan/imports.py
+++ b/banyan/banyan/imports.py
@@ -1,6 +1,0 @@
-# Standard Library
-
-import boto3
-import requests
-import toml
-from botocore.config import Config

--- a/banyan/banyan/sessions.py
+++ b/banyan/banyan/sessions.py
@@ -1,2 +1,9 @@
+SessionId = str
+
+
 def start_session():
     pass
+
+
+def get_session_id() -> SessionId:
+    return ""

--- a/banyan/banyan/typing.py
+++ b/banyan/banyan/typing.py
@@ -1,0 +1,9 @@
+from .annotation import PartitioningSpec
+from .utils_future_computation import (
+    FutureComputation,
+    FutureId,
+    Partitioning,
+    PartitioningMulti,
+    PartitionTypeId,
+    TaskGraph,
+)

--- a/banyan/banyan/utils_communication.py
+++ b/banyan/banyan/utils_communication.py
@@ -6,5 +6,6 @@ from typing import Any
 def send_to_client(data: Any):
     raise NotImplementedError()
 
+
 def receive_to_client():
     raise NotImplementedError()

--- a/banyan/banyan/utils_future_computation.py
+++ b/banyan/banyan/utils_future_computation.py
@@ -9,7 +9,8 @@ from hashlib import md5
 from typing import Any, Dict, List, Optional, Set, Union
 
 from typing_extensions import Self
-from utils_serialization import from_str, to_str
+
+from .utils_serialization import from_str, to_str
 
 """ID of a future computation created on the client side"""
 FutureId = str

--- a/banyan/poetry.lock
+++ b/banyan/poetry.lock
@@ -64,6 +64,14 @@ python-versions = ">=3.6.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
+name = "cloudpickle"
+version = "2.2.0"
+description = "Extended pickling support for Python objects"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -236,6 +244,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "typing-extensions"
+version = "4.4.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "urllib3"
 version = "1.26.13"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -251,7 +267,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0efef29c32b2003be45438bb4eda0b62749222e5d79a2fa0e7ab0c61020ede3a"
+content-hash = "f134085a230aa4c727d903651278bd41a5f7e04ec9396cdc5f7703e4556635df"
 
 [metadata.files]
 attrs = []
@@ -259,38 +275,22 @@ boto3 = []
 botocore = []
 certifi = []
 charset-normalizer = []
+cloudpickle = []
 colorama = []
 exceptiongroup = []
 idna = []
 iniconfig = []
 jmespath = []
-packaging = [
-    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
-    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
-]
+packaging = []
 pluggy = []
-pyparsing = [
-    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
-    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
-]
+pyparsing = []
 pytest = []
-python-dateutil = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
-]
-pytz = [
-    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
-    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
-]
+python-dateutil = []
+pytz = []
 requests = []
 s3transfer = []
-six = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
-]
-toml = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
+six = []
+toml = []
 tomli = []
+typing-extensions = []
 urllib3 = []

--- a/banyan/pyproject.toml
+++ b/banyan/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "banyan-python"
 version = "0.2.0"
-description = "Massively parallel cloud computing with popular Python libraries for analytics, processing, and simulation! "
+description = "Massively parallel cloud computing with popular Python libraries for analytics, processing, and simulation!"
 authors = ["Banyan Computing <support@banyancomputing.com>"]
 license = "Apache-2.0"
 readme = "README.md"
@@ -34,6 +34,8 @@ botocore = "^1.23.48"
 requests = "^2.27.1"
 toml = "^0.10.2"
 pytz = "^2021.3"
+typing-extensions = "^4.4.0"
+cloudpickle = "^2.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2"

--- a/banyan/tests/test_annotation.py
+++ b/banyan/tests/test_annotation.py
@@ -99,3 +99,22 @@ def test_record_task_with_constants():
         ],
     )
     assert len(res._task_graph[0].args) == 2
+
+
+def test_record_task_create_new_future():
+    arg = bn.Future()
+    res = bn.record_task(
+        "res",
+        filter_df,
+        [arg, lambda x: x * 2],
+        [
+            {arg: "Blocked", "res": "Blocked"},
+            {arg: "Grouped", "res": "Grouped"},
+            {
+                arg: bn.PartitionType("Grouped", {"key": "species"}),
+                "res": "Grouped",
+            },
+            {arg: "Replicated", "res": "Replicated"},
+        ],
+    )
+    assert len(res._task_graph[0].args) == 2

--- a/banyan/tests/test_annotation.py
+++ b/banyan/tests/test_annotation.py
@@ -1,0 +1,101 @@
+import banyan as bn
+from banyan.utils_future_computation import print_task_graph
+
+
+def filter_df(x, func=None):
+    return x
+
+
+def test_record_task():
+    arg = bn.Future()
+    res = bn.Future()
+    bn.record_task(
+        res,
+        filter_df,
+        arg,
+        [
+            {arg: "Blocked", res: "Blocked"},
+            {arg: "Grouped", res: "Grouped"},
+            {
+                arg: bn.PartitionType("Grouped", {"key": "species"}),
+                res: "Grouped",
+            },
+            {arg: "Replicated", res: "Replicated"},
+        ],
+    )
+
+    arg = res
+    res = bn.Future()
+    bn.record_task(
+        res,
+        filter_df,
+        arg,
+        [{arg: "Replicated", res: "Replicated"}],
+        static=res,
+    )
+
+    arg = res
+    res = bn.Future()
+    bn.record_task(
+        res,
+        filter_df,
+        arg,
+        [{arg: "Replicated", res: "Replicated"}],
+        static=[res],
+    )
+
+    assert len(arg._task_graph) == 2
+    assert len(res._task_graph) == 3
+    assert res._task_graph[0].results[0] == res._task_graph[1].args[0]
+    assert len(res._task_graph[0].partitioning_list) == 4
+    assert len(arg._task_graph[0].partitioning_list) == 4
+    pt = arg._task_graph[0].partitioning_list[2][arg._task_graph[0].args[0]]
+    assert pt.is_grouped
+    assert pt.params["key"] == "species"
+
+    arg = res
+    res = bn.Future()
+    bn.record_task(
+        res,
+        filter_df,
+        arg,
+        [
+            "Blocked",
+            "Consolidated",
+            {
+                arg: bn.PartitionType("Grouped", {"key": "species"}),
+                res: "Grouped",
+            },
+            bn.PartitionType("Grouped", {"key": "species"}),
+        ],
+    )
+    assert len(arg._task_graph) == 3
+    assert len(res._task_graph) == 4
+    assert len(res._task_graph[3].partitioning_list) == 4
+    for pt in [
+        res._task_graph[3].partitioning_list[2][res._task_graph[3].args[0]],
+        res._task_graph[3].partitioning_list[3][res._task_graph[3].args[0]],
+        res._task_graph[3].partitioning_list[3][res._task_graph[3].results[0]],
+    ]:
+        assert pt.is_grouped
+        assert pt.params["key"] == "species"
+
+
+def test_record_task_with_constants():
+    arg = bn.Future()
+    res = bn.Future()
+    bn.record_task(
+        [res],
+        filter_df,
+        [arg, lambda x: x * 2],
+        [
+            {arg: "Blocked", res: "Blocked"},
+            {arg: "Grouped", res: "Grouped"},
+            {
+                arg: bn.PartitionType("Grouped", {"key": "species"}),
+                res: "Grouped",
+            },
+            {arg: "Replicated", res: "Replicated"},
+        ],
+    )
+    assert len(res._task_graph[0].args) == 2

--- a/banyan/tests/test_config.py
+++ b/banyan/tests/test_config.py
@@ -1,4 +1,6 @@
-from banyan.config import *
+import os
+
+import banyan as bn
 
 user_id = "user1"
 api_key = "12345"
@@ -6,7 +8,7 @@ api_key = "12345"
 
 def test_args():
     banyanconfig_path = "tempfile_args.toml"
-    config = configure(
+    config = bn.configure(
         user_id=user_id, api_key=api_key, banyanconfig_path=banyanconfig_path
     )
     print(config)
@@ -15,7 +17,7 @@ def test_args():
         and config["banyan"]["api_key"] == api_key
     )
 
-    config = load_config(banyanconfig_path)
+    config = bn.config.load_config(banyanconfig_path)
     assert (
         config["banyan"]["user_id"] == user_id
         and config["banyan"]["api_key"] == api_key
@@ -32,13 +34,13 @@ def test_environ():
     os.environ["BANYAN_USER_ID"] = user_id
     os.environ["BANYAN_API_KEY"] = api_key
 
-    config = configure(banyanconfig_path=banyanconfig_path)
+    config = bn.configure(banyanconfig_path=banyanconfig_path)
     assert (
         config["banyan"]["user_id"] == user_id
         and config["banyan"]["api_key"] == api_key
     )
 
-    config = load_config(banyanconfig_path)
+    config = bn.config.load_config(banyanconfig_path)
     assert (
         config["banyan"]["user_id"] == user_id
         and config["banyan"]["api_key"] == api_key
@@ -52,19 +54,19 @@ def test_environ():
 
 def test_toml():
     banyanconfig_path = "tempfile_toml.toml"
-    configure(
+    bn.configure(
         user_id=user_id, api_key=api_key, banyanconfig_path=banyanconfig_path
     )
 
     del os.environ["BANYAN_USER_ID"]
     del os.environ["BANYAN_API_KEY"]
-    config = configure(banyanconfig_path=banyanconfig_path)
+    config = bn.configure(banyanconfig_path=banyanconfig_path)
     assert (
         config["banyan"]["user_id"] == user_id
         and config["banyan"]["api_key"] == api_key
     )
 
-    config = load_config(banyanconfig_path)
+    config = bn.config.load_config(banyanconfig_path)
     assert (
         config["banyan"]["user_id"] == user_id
         and config["banyan"]["api_key"] == api_key


### PR DESCRIPTION
Example usage for annotating `polars.groupby` in `bnpolars.groupby`:
```python
    def groupby(df, col):
        # df = polars.groupby(res) where df, res is Blocked | Consolidated | Grouped(key=col)
        return bn.record_task(
            df,
            polars.groupby,
            "res",
            [
                "Blocked",
                "Consolidated",
                bn.PartitionType("Grouped", {"key": col})
            ]
        )
```